### PR TITLE
Add Hermes Tweet resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,7 @@ npx claude-code-templates@latest --health-check
 | **claude-code-exporter** | NPM | Export Claude Code configs | [NPM](https://www.npmjs.com/package/claude-code-exporter) |
 | **Docker MCP Toolkit** | Integration | Docker-based MCP setup | [Blog](https://www.docker.com/blog/connect-mcp-servers-to-claude-desktop-with-mcp-toolkit/) |
 | **Claude Code Action** | CI/CD | GitHub Actions integration | [Marketplace](https://github.com/marketplace/actions/claude-code-action-official) |
+| **Hermes Tweet** | Plugin | Hermes Agent X/Twitter automation plugin | [GitHub](https://github.com/Xquik-dev/hermes-tweet) |
 
 ### 📊 Analytics & Monitoring
 


### PR DESCRIPTION
## Summary
- Add Hermes Tweet to the Development Tools table as a Claude and Hermes plugin resource.
- Use the public GitHub repository link and a compact objective description.

## Validation
- git diff --check
- curl -fsSI https://github.com/Xquik-dev/hermes-tweet returned HTTP 200
- gh pr list for Hermes Tweet and Xquik duplicates returned []